### PR TITLE
Use pkg-config to locate -lprofiler and -ltcmalloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ error-chain = "0.12.0"
 [features]
 default = []
 heap = []
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,19 @@
+extern crate pkg_config;
+
+/// Configures the crate to link against `lib_name`.
+///
+/// The library is first searched via the pkg-config file provided in
+/// `pc_name`, which provides us accurate information on how to find the
+/// library to link to. But because old gperftools did not supply such
+/// files, this falls back to using the linker's path.
+fn find_library(pc_name: &str, lib_name: &str) {
+    match pkg_config::Config::new().atleast_version("2.0").probe(pc_name) {
+        Ok(_) => (),
+        Err(_) => println!("cargo:rustc-link-lib={}", lib_name),
+    };
+}
+
+fn main () {
+    find_library("libprofiler", "profiler");
+    #[cfg(feature = "heap")] find_library("libtcmalloc", "tcmalloc");
+}

--- a/src/heap_profiler.rs
+++ b/src/heap_profiler.rs
@@ -34,7 +34,6 @@ lazy_static! {
     });
 }
 
-#[link(name = "tcmalloc")]
 #[allow(non_snake_case)]
 extern "C" {
     fn HeapProfilerStart(fname: *const c_char);

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -52,7 +52,6 @@ lazy_static! {
     });
 }
 
-#[link(name = "profiler")]
 #[allow(non_snake_case)]
 extern "C" {
     fn ProfilerStart(fname: *const c_char) -> i32;


### PR DESCRIPTION
There is no guarantee that these libraries are available on "standard"
locations, which means that simply linking to them with -l flags is
bound to fail.

For example: a user may have installed gperftools under their home
directory, in which case this crate cannot find it.

To resolve this, use pkg-config to locate the libraries.  This allows
this crate to learn all compiler and linker flags (in particular, -L)
needed to use them.